### PR TITLE
added a macOS dependency for ZeroMQ

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,8 @@ To try cl-jupyter you need :
    - or Clozure CL 1.10 or above (with native threads enabled) ...
 
    - ECL is planned, for other implementations please fill an issue.
+ 
+ - ZeroMQ (cf. http://zeromq.org) On macOS: 'brew install zeromq'
 
  - Quicklisp (cf. http://www.quicklisp.org)
 


### PR DESCRIPTION
I needed to install ZeroMQ on macOS using "brew install zeromq" to get the cl-jupyter kernel working on my system.