### PR TITLE
Modified regex for checking ccl version

### DIFF
--- a/install-cl-jupyter.py
+++ b/install-cl-jupyter.py
@@ -215,7 +215,7 @@ elif config.lisp_implementation == "ccl":
 
 
     import re
-    m = re.match(r".*([0-9]+\.[0-9]+)", ccl_version_string)
+    m = re.match(r".*?([0-9]+\.[0-9]+)", ccl_version_string)
     if not m:
         halt("Error: issue with ccl version string (please report)")
 


### PR DESCRIPTION
CCL's version string format is `Version 1.11.5  (DarwinX8664)`.
Using the original regex makes installation script think the version is 1.5, not 1.11.
Modified regex.